### PR TITLE
rename now to vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 ## Goal
 
-This repo contains examples of how to add *Basic Authentication* to a Now deployment using various languages / frameworks, along with some numbers that show the differences between each method.
+This repo contains examples of how to add *Basic Authentication* to a Vercel deployment using various languages / frameworks, along with some numbers that show the differences between each method.
 
 Each example contains its own README file with some additional information.
 
 ## Structure
 
 - The `_static` directory contains the source code for the "website" that each implementation serves for demonstration purposes : HTML, CSS, images ... <sup>1</sup>
-- All the other directories are the different ways you can add Basic Authentication to a Now deployment. Checkout their code to see how to implement it in your project
+- All the other directories are the different ways you can add Basic Authentication to a Vercel deployment. Checkout their code to see how to implement it in your project
 
 <sup>1</sup> The demo website has a public area and a restricted `/admin` area **(username / pass : `admin` / `admin`)**.
 

--- a/node-express/.gitignore
+++ b/node-express/.gitignore
@@ -1,1 +1,1 @@
-.now
+.vercel

--- a/node-express/index.js
+++ b/node-express/index.js
@@ -9,7 +9,7 @@ const app = express();
 
 app.use('/admin', basicAuth({
   challenge: true,
-  realm: 'now-basic-auth.node-express',
+  realm: 'vercel-basic-auth.node-express',
   users: { 'admin': 'admin' },
   unauthorizedResponse: 'Restricted area, please login (admin:admin).'
 }));

--- a/node-express/vercel.json
+++ b/node-express/vercel.json
@@ -2,7 +2,7 @@
   "public": true,
   "builds": [{
     "src": "index.js",
-    "use": "@now/node"
+    "use": "@vercel/node"
   }],
   "routes": [
     { "src": "/.*", "dest": "index.js" }

--- a/node-static-auth/.gitignore
+++ b/node-static-auth/.gitignore
@@ -1,1 +1,1 @@
-.now
+.vercel

--- a/node-static-auth/README.md
+++ b/node-static-auth/README.md
@@ -1,3 +1,3 @@
 This example uses the [static-auth](https://www.npmjs.com/package/static-auth) package.
 
-As of the time of writing, this is the **easiest solution** to add Basic Authentication to a Now deployment.
+As of the time of writing, this is the **easiest solution** to add Basic Authentication to a Vercel deployment.

--- a/node-static-auth/index.js
+++ b/node-static-auth/index.js
@@ -10,7 +10,7 @@ const app = protect(
   (username, password) => safeCompare(username, 'admin') && safeCompare(password, 'admin'),
   {
     directory: __dirname + '/_static',
-    realm: 'now-basic-auth.node-static-auth',
+    realm: 'vercel-basic-auth.node-static-auth',
     onAuthFailed: res => {
       res.end('Restricted area, please login (admin:admin).');
     }

--- a/node-static-auth/vercel.json
+++ b/node-static-auth/vercel.json
@@ -2,7 +2,7 @@
   "public": true,
   "builds": [{
     "src": "index.js",
-    "use": "@now/node"
+    "use": "@vercel/node"
   }],
   "routes": [
     { "src": "/.*", "dest": "index.js" }

--- a/node/.gitignore
+++ b/node/.gitignore
@@ -1,1 +1,1 @@
-.now
+.vercel

--- a/node/index.js
+++ b/node/index.js
@@ -24,7 +24,7 @@ const app = async (req, res) => {
   if (req.url.startsWith('/admin')) {
     const authorized = await auth(req, res);
     if (!authorized) {
-      res.writeHead(401, { 'WWW-Authenticate': 'Basic realm="now-basic-auth.node"' });
+      res.writeHead(401, { 'WWW-Authenticate': 'Basic realm="vercel-basic-auth.node"' });
       return res.end('Restricted area, please login (admin:admin).');
     }
   }

--- a/node/vercel.json
+++ b/node/vercel.json
@@ -2,7 +2,7 @@
   "public": true,
   "builds": [{
     "src": "index.js",
-    "use": "@now/node"
+    "use": "@vercel/node"
   }],
   "routes": [
     { "src": "/.*", "dest": "index.js" }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "now-basic-auth",
-  "repository": "git@github.com:flawyte/now-basic-auth.git",
+  "name": "vercel-basic-auth",
+  "repository": "git@github.com:flawyte/vercel-basic-auth.git",
   "author": "Mickaël Allonneau <mickael.allonneau@gmail.com>",
   "license": "MIT",
   "private": true,
@@ -10,14 +10,14 @@
     "install:node-express": "cd node-express/ && yarn",
     "install:node-static-auth": "cd node-static-auth/ && yarn",
 
-    "node": "cd node/ && now dev",
-    "deploy-node": "cd node && now",
+    "node": "cd node/ && vercel dev",
+    "deploy-node": "cd node && vercel",
 
-    "node-express": "cd node-express/ && now dev",
-    "deploy-node-express": "cd node-express && now",
+    "node-express": "cd node-express/ && vercel dev",
+    "deploy-node-express": "cd node-express && vercel",
 
-    "node-static-auth": "cd node-static-auth/ && now dev",
-    "deploy-node-static-auth": "cd node-static-auth && now",
+    "node-static-auth": "cd node-static-auth/ && vercel dev",
+    "deploy-node-static-auth": "cd node-static-auth && vercel",
 
     "test": "TEST_VARIANT=no-credentials jest && TEST_VARIANT=invalid-credentials jest && TEST_VARIANT=valid-credentials jest",
     "update-static-dirs": "bash update-static-dirs.sh"

--- a/test.ts
+++ b/test.ts
@@ -84,7 +84,7 @@ function adminAreaTest(url: string, expectedResponseCode: number) {
       if (res.status === 401) {
         const body = await res.text();
         expect(body).toBe('Restricted area, please login (admin:admin).');
-        expect(res.headers.get('www-authenticate')).toMatch(/Basic realm="now-basic-auth\.[a-z-]+"/);
+        expect(res.headers.get('www-authenticate')).toMatch(/Basic realm="vercel-basic-auth\.[a-z-]+"/);
       }
     });
   });


### PR DESCRIPTION
I renamed `now` to `vercel` to avoid confusion with the old name and to improve seo. (https://vercel.com/blog/zeit-is-now-vercel)

⚠️ **I changed `"name"` and `"repository"` in the `/package.json`. Please rename this repository to `vercel-basic-auth`** before merging this pr.

